### PR TITLE
Add cats.implicits._ import

### DIFF
--- a/src/main/g8/core/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/core/src/main/scala/$package$/Main.scala
@@ -1,6 +1,7 @@
 package $package$
 
 import cats.effect._
+import cats.implicits._
 
 object Main extends IOApp {
 


### PR DESCRIPTION
I very well could be wrong, but I believe that `cats.implicits._` is required for `.as(ExitCode.Success)`

Without the import I was getting the following:

```
[error]     value as is not a member of cats.effect.IO[Unit]
[error]     IO(println("I am a new project!")).as(ExitCode.Success)
[error]                                        ^