### PR TITLE
Update README and docs to ref scala 2.12

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -4,7 +4,7 @@
 
 ## Quick Start
 
-To use $name$ in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use $name$ in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala

--- a/src/main/g8/site/docs/index.md
+++ b/src/main/g8/site/docs/index.md
@@ -7,7 +7,7 @@ layout: home
 
 ## Quick Start
 
-To use $name$ in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use $name$ in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala


### PR DESCRIPTION
The g8 build defaults to 2.12 and 2.13 now but the README still references 2.11, this PR updates that.